### PR TITLE
Change Measurement model name

### DIFF
--- a/tutorial/02 - Extended Kalman.ipynb
+++ b/tutorial/02 - Extended Kalman.ipynb
@@ -237,8 +237,8 @@
    },
    "outputs": [],
    "source": [
-    "from stonesoup.models.measurement.nonlinear import RangeBearingGaussianToCartesian\n",
-    "measurement_model = RangeBearingGaussianToCartesian(\n",
+    "from stonesoup.models.measurement.nonlinear import CartesianToBearingRange\n",
+    "measurement_model = CartesianToBearingRange(\n",
     "    4, # Number of state dimensions (position and velocity in 2D)\n",
     "    (0,2), # Mapping measurement vector index to state index\n",
     "    np.diag([np.radians(0.2), 1]),  # Covariance matrix for Gaussian PDF\n",


### PR DESCRIPTION
The measurement model should be 'CartesianToBearingRange' if using stonesoup current version.